### PR TITLE
Add Verse Key in Question/Answer Format Response

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,10 @@ When the `options.value` is set to 1, it means the answer is correct, while when
 {
   "data": [
     {
-      "question": " قُلْ هُوَ ٱللَّهُ أَحَدٌ",
+      "question": {
+        "text": " قُلْ هُوَ ٱللَّهُ أَحَدٌ",
+        "verseKey": "112:1"
+      },
       "options": [
         {
           "text": "Al-Masad",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -61,6 +61,16 @@ export const getVerseTextById = (id: number) => {
   return find.text_uthmani;
 };
 
+export const getVerseKeyById = (id: number) => {
+  const find = getQuran().find((item) => item.id === id);
+
+  if (!find) {
+    throw new Error("Failed to find verse");
+  }
+
+  return find.verse_key;
+}
+
 const chapterNames = [
   "Al-Fatihah",
   "Al-Baqarah",

--- a/src/quiz/guessSurah.ts
+++ b/src/quiz/guessSurah.ts
@@ -3,6 +3,7 @@ import {
   getManyVerseIdBySurahId,
   getSurahBySurahId,
   getSurahByVerseId,
+  getVerseKeyById,
   getVerseTextById,
 } from "~/data";
 import { randomizeOptions } from "~/quiz/helpers";
@@ -48,7 +49,10 @@ const guessSurahBySurah = (props: GuessVerse) => {
     options = options.sort(() => 0.5 - Math.random()).slice(0, 3);
 
     return randomizeOptions({
-      question: getVerseTextById(questionVerseId),
+      question: {
+        text: getVerseTextById(questionVerseId),
+        verseKey: getVerseKeyById(questionVerseId),
+      },
       options: [
         ...options.map((option) => {
           return {
@@ -79,7 +83,10 @@ const guessSurahBySurah = (props: GuessVerse) => {
 };
 
 type CreateQuizOutput = {
-  question: string;
+  question: {
+    text: string;
+    verseKey: string;
+  };
   options: {
     text: string;
     value: number;

--- a/src/quiz/guessVerse.ts
+++ b/src/quiz/guessVerse.ts
@@ -4,6 +4,7 @@ import {
   getManyVerseIdBySurahId,
   getManyVerseIdByJuzId,
   getVerseTextById,
+  getVerseKeyById,
 } from "~/data";
 import {
   getIndexOfQuestionAnswerOptions,
@@ -126,17 +127,22 @@ const createGuessVerseQuiz = (props: CreateGuessVerseQuiz) => {
   const { questionVerseId, answerVerseId, optionsVerseId } = props;
 
   const result = {
-    question: getVerseTextById(questionVerseId),
+    question: {
+      text: getVerseTextById(questionVerseId),
+      verseKey: getVerseKeyById(questionVerseId),
+    },
     options: [
       ...optionsVerseId.map((option) => {
         return {
           text: getVerseTextById(option),
           value: 0,
+          verseKey: getVerseKeyById(option),
         };
       }),
       {
         text: getVerseTextById(answerVerseId),
         value: 1,
+        verseKey: getVerseKeyById(answerVerseId),
       },
     ],
   };

--- a/src/quiz/helpers.ts
+++ b/src/quiz/helpers.ts
@@ -42,10 +42,10 @@ export const getIndexOfQuestionAnswerOptions = (
 };
 
 export const randomizeOptions = (result: {
-  question: string;
+  question: { text: string; verseKey: string };
   options: { text: string; value: number }[];
 }): {
-  question: string;
+  question: { text: string; verseKey: string };
   options: { text: string; value: number }[];
 } => {
   const randomizedOptions = [...result.options];


### PR DESCRIPTION
I think adding verse key in question/answer object will make it easier to parse an audio

Context:
i'm trying to build a quiz client side for this api, but i think one of the best solution to guess a verse is by listening an audio + reciting it, by adding verseKey will make it easier to identify which verses of this question/answer, so it can be attach with an audio from external library, i'll use this [library](https://github.com/gadingnst/quran-api) for the audio quran

**i know this is changing the api format, so it can be a major changes, sorry for the inconvenience.**

I hope you can reconsider this idea, thank you 🚀 🍀 